### PR TITLE
feature/minor-useTimeout-and-useInterval-improvements

### DIFF
--- a/__tests__/timers/useInterval.test.ts
+++ b/__tests__/timers/useInterval.test.ts
@@ -183,6 +183,28 @@ describe( 'useInterval', () => {
 	
 		} )
 
+
+		it( 'set isActive to true only when timer was previously inactive', () => {
+		
+			const callback		= jest.fn()
+			const delay			= 1000
+			const autoplay		= false
+			const updateState	= true
+	
+			const { result } = renderHook( () => (
+				useInterval( callback, { delay, autoplay, updateState } )
+			) )
+
+			expect( result.current.isActive ).toBe( false )
+	
+			act( () => {
+				result.current.start()
+			} )
+
+			expect( result.current.isActive ).toBe( true )
+
+		} )
+
 	} )
 	
 	
@@ -224,6 +246,28 @@ describe( 'useInterval', () => {
 			
 			expect( callback ).not.toHaveBeenCalled()
 			expect( clearTimeout ).not.toHaveBeenCalled()
+
+		} )
+
+
+		it( 'sets isActive to false only when timer is running and updateState is true', () => {
+		
+			const callback		= jest.fn()
+			const delay			= 1000
+			const autoplay		= true
+			const updateState	= true
+	
+			const { result } = renderHook( () => (
+				useInterval( callback, { delay, autoplay, updateState } )
+			) )
+
+			expect( result.current.isActive ).toBe( true )
+	
+			act( () => {
+				result.current.stop()
+			} )
+
+			expect( result.current.isActive ).toBe( false )
 
 		} )
 

--- a/__tests__/timers/useTimeout.test.ts
+++ b/__tests__/timers/useTimeout.test.ts
@@ -9,6 +9,7 @@ describe( 'useTimeout', () => {
 	} )
 
 	afterAll( () => {
+		jest.clearAllTimers()
 		jest.useRealTimers()
 	} )
 
@@ -181,6 +182,28 @@ describe( 'useTimeout', () => {
 	
 		} )
 
+
+		it( 'set isActive to true only when timer was previously inactive', () => {
+
+			const callback		= jest.fn()
+			const delay			= 1000
+			const autoplay		= false
+			const updateState	= true
+	
+			const { result } = renderHook( () => (
+				useTimeout( callback, { delay, autoplay, updateState } )
+			) )
+
+			expect( result.current.isActive ).toBe( false )
+	
+			act( () => {
+				result.current.start()
+			} )
+
+			expect( result.current.isActive ).toBe( true )
+
+		} )
+
 	} )
 	
 	
@@ -222,6 +245,28 @@ describe( 'useTimeout', () => {
 			
 			expect( callback ).not.toHaveBeenCalled()
 			expect( clearTimeout ).not.toHaveBeenCalled()
+
+		} )
+
+
+		it( 'sets isActive to false only when timer is running and updateState is true', () => {
+
+			const callback		= jest.fn()
+			const delay			= 1000
+			const autoplay		= true
+			const updateState	= true
+	
+			const { result } = renderHook( () => (
+				useTimeout( callback, { delay, autoplay, updateState } )
+			) )
+
+			expect( result.current.isActive ).toBe( true )
+	
+			act( () => {
+				result.current.stop()
+			} )
+
+			expect( result.current.isActive ).toBe( false )
 
 		} )
 

--- a/src/timers/useInterval.ts
+++ b/src/timers/useInterval.ts
@@ -84,7 +84,26 @@ export function useInterval<T extends readonly unknown[]>(
 	const [ isActive, setIsActive ] = useState( autoplay )
 
 
+	/**
+	 * Clear timer without state update.
+	 * 
+	 * @returns `true` if timer was running, `false` otherwise.
+	 */
+	const clear = useCallback( () => {
+
+		if ( ! timerRef.current ) return false
+
+		clearInterval( timerRef.current )
+		timerRef.current = undefined
+
+		return true
+
+	}, [] )
+
+
 	const start = useCallback<StartTimer>( () => {
+
+		const wasActive = clear()
 
 		if ( runOnStart ) {
 			if ( args ) {
@@ -96,24 +115,18 @@ export function useInterval<T extends readonly unknown[]>(
 		
 		timerRef.current = setInterval( callback, delay, ...( args || [] ) )
 		
-		if ( updateState ) setIsActive( true )
+		if ( ! wasActive && updateState ) setIsActive( true )
 
 		return timerRef.current
 
-	}, [ delay, args, updateState, runOnStart, callback ] )
+	}, [ delay, args, updateState, runOnStart, callback, clear ] )
 
 
 	const stop = useCallback<StopTimer>( () => {
 
-		if ( ! timerRef.current ) return
+		if ( clear() && updateState ) setIsActive( false )
 
-		clearInterval( timerRef.current )
-		timerRef.current = undefined
-
-		if ( updateState ) setIsActive( false )
-	
-
-	}, [ updateState ] )
+	}, [ updateState, clear ] )
 
 
 	useEffect( () => {

--- a/src/timers/useTimeout.ts
+++ b/src/timers/useTimeout.ts
@@ -99,7 +99,26 @@ export function useTimeout<T extends readonly unknown[]>(
 	const [ isActive, setIsActive ] = useState( autoplay )
 
 
+	/**
+	 * Clear timer without state update.
+	 * 
+	 * @returns `true` if timer was running, `false` otherwise.
+	 */
+	const clear = useCallback( () => {
+
+		if ( ! timerRef.current ) return false
+
+		clearTimeout( timerRef.current )
+		timerRef.current = undefined
+
+		return true
+
+	}, [] )
+
+
 	const start = useCallback<StartTimer>( () => {
+
+		const wasActive = clear()
 
 		if ( runOnStart ) {
 			if ( args ) {
@@ -110,28 +129,24 @@ export function useTimeout<T extends readonly unknown[]>(
 		}
 		
 		timerRef.current = setTimeout( () => {
+			timerRef.current = undefined
 			if ( updateState ) setIsActive( false )
 			if ( args ) return callback( ...args )
 			callback()
 		}, delay )
 
-		if ( updateState ) setIsActive( true )
+		if ( ! wasActive && updateState ) setIsActive( true )
 
 		return timerRef.current
 
-	}, [ delay, args, updateState, runOnStart, callback ] )
+	}, [ delay, args, updateState, runOnStart, callback, clear ] )
 
 
 	const stop = useCallback<StopTimer>( () => {
-		
-		if ( ! timerRef.current ) return
 
-		clearTimeout( timerRef.current )
-		timerRef.current = undefined
+		if ( clear() && updateState ) setIsActive( false )
 
-		if ( updateState ) setIsActive( false )
-
-	}, [ updateState ] )
+	}, [ updateState, clear ] )
 
 
 	useEffect( () => {


### PR DESCRIPTION
core changes:

- optionally run the callback "on start" before timers starts.
- reset last active timer before executing "start" again to avoid timer accumulations.
- prevent use-less state updates.